### PR TITLE
add block explorer documentation mds

### DIFF
--- a/documentation/explorer/authentication/00_authentication_api.md
+++ b/documentation/explorer/authentication/00_authentication_api.md
@@ -1,0 +1,37 @@
+# APIKey API
+
+The APIKey API can be used to generate new APIKeys, these keys are required to authenticate against the rest of the API endpoints.
+
+## The APIkey
+
+The APIKey is a string value in base 64 encoding.
+
+```json
+"MWRkMWMxMWEtMzUzMC00YTRmLTg5NDQtZjdkZDMwN2YwMjIy"
+```
+
+## Usage
+
+The APIKey is used as a bearer token and should be set in the `Authorization` header of the core APIs.
+
+```json
+  Authorization:"Bearer MWRkMWMxMWEtMzUzMC00YTRmLTg5NDQtZjdkZDMwN2YwMjIy"
+```
+
+---
+
+## /createapikey
+
+The `/createapikey` generates a new APIKey for the user to authenticate with, it requires no parameters or sign-up.
+
+```
+GET /auth/createapikey
+```
+
+### Parameters
+
+No parameters.
+
+### Response:
+
+Retrieves an authentication token.

--- a/documentation/explorer/block/00_block_api.md
+++ b/documentation/explorer/block/00_block_api.md
@@ -1,0 +1,150 @@
+# Block information API
+
+The block information api exposes several endpoints that allow the user to retrieve the cached state of blocks of the Aleo network.
+
+## The block object
+
+### Attributes
+
+#### hash (string)
+
+Hash of all of the block header data within this attribute.
+
+#### height (number)
+
+The height this current block is located at.
+
+#### canonical (boolean)
+
+A boolean value whether this block is currently in the longest chain.
+
+#### previousBlockHash (string)
+
+The hash of the previous block header.
+
+#### merkleRoot (string)
+
+Merkle root representing the transactions in the block.
+
+#### pedersonMerkleRoot (string)
+
+Merkle root representing the state of the block.
+
+#### time (number)
+
+Block timestamp is a Unix epoch time (UTC) when the miner started hashing the header (according to the miner and checked by every other miner).
+
+#### size (number)
+
+The size in bytes of the current block (sum of the size of all transactions + the values listed within this object).
+
+#### nonce (number)
+
+Nonce for solving the PoSW puzzle.
+
+#### proof (string)
+
+A succinct proof that attests to the transactions included in this block.
+
+#### transactions (Array of hashes (strings))
+
+A list of all the transactions included in this block.
+
+#### difficultyTarget (number)
+
+Proof of Succinct Work algorithm difficulty target for this block.
+
+### Example
+
+```json
+{
+  "transactions": ["7a38bc5d1fd2c1f3355406eec505bcd722197d2dc679c1cf3465a3c41f51b615"],
+  "hash": "e6dfa55eb904c386a70c8858f13f1bc2155fd3b506d17e63e456b9c30f04fd80",
+  "height": 0,
+  "merkleRoot": "fc88e8b29c042ae4daa7000e8f4f38ce17b66afb771df5b78a0f6407862da12a",
+  "pedersenMerkleRoot": "38db6fa1fcd0c65976eb6366de3a0389730d94670dbf8850afba13700e7d5b05",
+  "time": 1592698396,
+  "nonce": 0,
+  "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "size": 1479,
+  "proof":"5082a337d4b5879edaff32bce111463cdf3ee4d1cb0b4c700ce5035daedc0e114ef37ef3c1e891ae82ba1198f42e6301e0b70f8786f2fb09b38cd2107c0321ce03f3a3a3e7205f022b64a9ecee51daacbd8044c2cf59d640fa9030d14210ed000082e1ba324654c6388715d7ed7627dd11dc6b5032707bdf385d0b6282c6a79e229c4275aae7843950ceb5678e600d2801b75258c608adc1beb051ef678e121b272f55ddb69bc1b1ccccb759c611857b002622810741de54b7fdd167227c894e01d62a6baf2bb0eb739720ff797f758ca2e0c6bd3eb6eb2273ab0b4f402d44deebb77b692c96f28f126656e060dc900d00d12d9283aaf22a59399d8d9532e09254c44eeb850dcb4e5df3ae37bfec2472d1fbecc570307aa88569dbe037fbcc0901001aacd8db440a52ab82cba6f3f53a97617301bc04cedb156fef44142fef1bab7a81e0c6aa052ffd3255331296eab5bd003dc9266a83dd5829702609bb9692f37280c4788c16e8fb2650613533ec3b5312fc29f4c5162647f47cd0f7cb28e3740100"
+  "difficultyTarget": 576460752303423500,
+  "canonical": true,
+}
+```
+
+---
+
+## /getbestblock
+
+The `/getbest` endpoint retrieves the latest canonical block.
+
+```
+GET /block/getbest
+```
+
+### Parameters
+
+No parameters.
+
+### Response:
+
+Retrieves a block object.
+
+## /getbyheight
+
+The `/getbyheight` endpoint retrieves a canonical block based on the given height (if one exists at that height).
+
+```
+POST /block/getbyheight
+```
+
+### Parameters
+
+#### height <span style="color:red">required</span>
+
+A `positive integer` value or the string `latest` is accepted, where the integer will return the block corresponding to that height and the string latest will return the latest canonical block.
+
+### Response:
+
+Retrieves a block object.
+
+## /getbyheightrange
+
+The `/getbyheightrange` endpoint retrieves a list of canonical blocks based on the given height range.
+
+```
+POST /block/getbyheightrange
+```
+
+### Parameters
+
+#### from <span style="color:red">required</span>
+
+A `non negative integer` value indicating the start height to return blocks from.
+
+#### to <span style="color:grey">optional</span>
+
+A `positive integer` value or the string `latest` is accepted, where the integer will return all the canonical blocks up to that height and the string latest will return all the blocks up to the latest canonical block.
+
+### Response:
+
+Retrieves a list of block objects block object.
+
+## /getbyhash
+
+The `/getbyhash` endpoint retrieves a canonical block based on the given hash (if one exists at that hash).
+
+```
+POST /block/getbyhash
+```
+
+### Parameters
+
+#### hash <span style="color:red">required</span>
+
+A string value that represents a blockhash. This string can be either 64 or 66 characters long, if the string is 66 characters the first two characters should be `0x`.
+
+### Response:
+
+Retrieves a block object.

--- a/documentation/explorer/metrics/00_metrics_api.md
+++ b/documentation/explorer/metrics/00_metrics_api.md
@@ -1,0 +1,202 @@
+# Metrics information API
+
+The Metric information api exposes one endpoints that allow the user to retrieve the cached state of metrics over a certain amount of blocks of the Aleo network.
+
+## The metric object
+
+### Attributes
+
+#### totalBlocks (metric {value: number, unit: string, title: string})
+
+Number of canonical blocks on chain.
+
+#### timeLastBlock (metric {value: number, unit: string, title: string})
+
+Block timestamp is a Unix epoch time (UTC) when the miner started hashing the header (according to the miner and checked by every other miner) of the last block in the range.
+
+#### totalTransactions (metric {value: number, unit: string, title: string})
+
+Number of canonical transactions on chain.
+
+#### avgTransactionFee (metric {value: number, unit: string, title: string})
+
+Average of all canonical transaction fees in requested range.
+
+#### lastBlockReward (metric {value: number, unit: string, title: string})
+
+BlockReward of last block in requested range.
+
+#### nodesOnlineNow (metric {value: number, unit: string, title: string})
+
+Number of nodes online (best guess metric).
+
+#### avgBlockTime (metric {value: number, unit: string, title: string})
+
+Average of all canonical block times.
+
+#### snarksPerSecond (metric {value: number, unit: string, title: string})
+
+<todo>
+
+#### medianConfirmationTime (metric {value: number, unit: string, title: string})
+
+Median of all block times.
+
+#### transactionFeePerByte (metric {value: number, unit: string, title: string})
+
+Average amount of bytes per fee generating transaction.
+
+#### totalFeesPayedToMiners (metric {value: number, unit: string, title: string})
+
+The total amount of transaction fees paid to miners in requested range.
+
+#### avgNodesOnline (metric {value: number, unit: string, title: string})
+
+Average number of nodes online (best guess metric) in requested range.
+
+### Example
+
+```json
+{
+  {
+    totalBlocks: {
+      value: 6,
+      unit: 'blocks',
+      title: ''
+    },
+    totalTransactions: {
+      value: 28,
+      unit: 'txes',
+      title: ''
+    },
+    timeLastBlock: {
+      value: 1593146844,
+      unit: 'timeStamp in seconds',
+      title: ''
+    },
+    avgTransactionFee: {
+      value: 1000,
+      unit: 'blocks',
+      title: ''
+    },
+    lastBlockReward: {
+      value: -1000,
+      unit: 'AleoCredits',
+      title: ''
+    },
+    nodesOnlineNow: {
+      value: 3,
+      unit: 'nodes',
+      title: ''
+    },
+    avgBlockTime: {
+      value: 25,
+      unit: 'seconds',
+      title: ''
+    },
+    snarksPerSecond: {
+      value: 25,
+      unit: 'snarks per second',
+      title: ''
+    },
+    medianConfirmationTime: {
+      value: 25,
+      unit: 'seconds',
+      title: ''
+    },
+    transactionFeePerByte: {
+      value: 1.0256410256410255,
+      unit: 'AleoCredits per byte',
+      title: ''
+    },
+    totalFeesPayedToMiners: {
+      value: 21000,
+      unit: 'AleoCredits',
+      title: ''
+      },
+    avgNodesOnline: {
+      value: 2.142857142857143,
+      unit: 'nodes',
+      title: '' }
+  }
+}
+```
+
+---
+
+## /get
+
+The `/get` endpoint retrieves a metric based on the last sequence of blocks.
+
+```
+POST /metrics/get
+```
+
+### Parameters
+
+#### blocks <span style="color:red">required</span>
+
+A number value representing the amount of blocks, starting from the best block, to use to calculate the metrics.
+
+### Response:
+
+Retrieves a metric object.
+
+---
+
+## The graphMetric object
+
+### Attributes
+
+#### txCount (number)
+
+Total amount of transactions, providing a fee, included in slice.
+
+#### feeSum (number))
+
+Sum of transaction fees included in slice
+
+#### start (number)
+
+Block timestamp is a Unix epoch time (UTC) of first block included in slice
+
+#### end (number)
+
+Block timestamp is a Unix epoch time (UTC) of last block included in slice
+
+### Example
+
+```json
+[
+  {
+    txCount: 3;
+    feeSum: 1000;
+    start: 1593146844;
+    end: 1593146875;
+  }
+]
+```
+
+---
+
+## /graph
+
+The `/graph` endpoint retrieves temporal data related to the amount of transactions and the sum of their fees.
+
+```
+POST /metrics/get
+```
+
+### Parameters
+
+#### interval
+
+A number value representing the amount of time in seconds for each slice.
+
+#### amount
+
+A number value representing the amount of slices requested.
+
+### Response:
+
+Retrieves a graphMetric array of interval slices.

--- a/documentation/explorer/transaction/00_transaction_api.md
+++ b/documentation/explorer/transaction/00_transaction_api.md
@@ -1,0 +1,166 @@
+# Transaction information API
+
+The Transaction information api exposes several endpoints that allow the user to retrieve the cached state of transactions of the Aleo network.
+
+## The transaction object
+
+### Attributes
+
+#### hash (string)
+
+Hash of all of the transaction attributes.
+
+#### parentBlock (block object or string)
+
+The parentblock of this current transaction, can either be a block object or a string referencing a blockhash.
+
+#### memo (string)
+
+An optional 32 byte memo field.
+
+#### newCommitments (string)
+
+List of commitments corresponding to newly produced records in this transaction.
+
+#### OldSerialNumbers (string)
+
+List of serial numbers corresponding to records consumed in this transaction.
+
+#### size (number)
+
+The size of the current transaction in bytes.
+
+#### digest (string)
+
+The merkle root hash of the block this transaction is transacted from
+
+#### transactionProof (string)
+
+A succinct proof that the predicate proofs (applications) ran correctly, the inner proof was valid, and that the outputs were verified to be correct.
+
+#### localDataCommitment (number)
+
+Commitment to local data (used to verify the outer proof).
+
+#### predicateDataCommitment (number)
+
+Commitment to the predicate state (used to verify the outer proof).
+
+#### valueBalance (number)
+
+The transaction fee for the miner (positive number). The mining reward for the miner (negative number).
+
+#### signatures (array of two hashes (strings))
+
+List of signatures authorizing each of the old records to be spent (Miner checks that each signature corresponds to the serial number of an old record)
+
+#### parentBlock (excerpt of block object)
+
+Core values of the block this transaction is a part of (time of block, block hash, which height the block is at and wether it is canonical or not).
+
+### Example
+
+```json
+{
+  "hash": "38f4c040b6bf4f507dfeffdaceb895450a12a56e3290547fd6803ee2144a3412",
+  "memo": "a192433de8dd30bdad8aa23ea95a2dce147f4b1a5821d810e20aa3981eb3d40a",
+  "newCommitments": [
+    "abc1b342489143d0de04980ed154fe2063ad89b46d1632c894d7edb432d7cc05",
+    "1350d1e7e57d3f5763bfe534d36d624d2fccd73315523d303c6dee1d4fcb7f0b"
+  ],
+  "oldSerialNumbers": [
+    "c96c5028c0e6ea668628c4b631d9b9c2dc7de6ea66151571b518e903fb712205",
+    "4474b7b139eeb1554a017d92ef52c19bf6d629c071aaebaa542f30dc20101801"
+  ],
+  "size": 975,
+  "valueBalance": -100,
+  "digest": "54db5e71a8365c8edbda28b4f66e9f657c613efac056fc870eedd57833e2e408",
+  "transactionProof": "78b07eb75ea173613fd2a6a31306efa2c7f197fbd40c5b584f4adf20a2ee0713ebe06166c136df07f4e8f1c4e62082b446a6b1aed8a956aa6f689c8ad50023ab224d3c9a15a6df99edf441ca292dbe6ff3e8950735fb8c76d5f1823395b30c01b426c2bda6d89bc1d5ccbb18d4553bbb4b3375a0c2479f80c73f2f82988be86007e7c9e59dd3e32cd9bc326a52b920169bac12ea968e97e440bd5be7f89ed9db06e1345520f8092b8882bd7859f6a76160c516be08d69692a68a77efa4bab70000522a186592ea6deb08010af62485152ba0f1a59f7ec0d7fe5d464b934814db811d866cd55122d7caeee9348fa3340a60e32390762a1c1c1b4468bf36886341d1c31c28856c095cc3915fac59d6f533164c06e9706725735483f1a5db5026ec003a0d7fce4ec98f87b92e0049de8b64d40e59cb56e1ec39e0a9bb9aabb5ae1379c311e7f4286e5f716a1eb95a61827e20c30dd8ad270ba241ba2f22443bd64651c0c5eefeadf8857338d991a0563e88d823b7d086437ff8e4a4ea3f347e135400004b7a70aaa71954693c68facfbdd3de131809df5cd5abcf86c62d3f522d42ef02bd9ac0283904237dbdc63f4d0868fb5a4d39da3a6c7d07f0ca6494ceed96a6982808d54dda077fea253348cf022126590c3230e90e8c5cfb349439c16226b100912844666b329fad72f2ebbdabf547680ce9b0dfe7998f08f1226c258a4b3a65da3e0ec7b740a235d39f65661f82fc57deb3dd9356f3e7a0230ddc602b7a9516018c0c266f4021541cc942966cb6dc7c9f31f3dc46b935d05551fcec0aec480000",
+  "localDataCommitment": "25895c996977f334e73617f7652e6e1f1f460febc137e45ab2edf49a176d8d01",
+  "predicateCommitment": "d4ff4c434a91eddc7a85575e2d6e773b76ec1d3f26d069b8a6aed7b58b8fa68b",
+  "signatures": [
+    "91fa6c5216de064f5b255dd2c708366db07c0a9e3bc41e217394cfdccede14040000000000000000000000000000000000000000000000000000000000000000",
+    "b530081532a0a9b78f18845a256957dc6cce196ec883f2be262bb8ab32ced8010000000000000000000000000000000000000000000000000000000000000000"
+  ],
+  "parentBlock": {
+    "hash": "46eee8828773c13b1927a9b91a91dfbc6ad877323316e11176941a7b22711093",
+    "height": 0,
+    "time": 1593478069,
+    "canonical": true
+  }
+}
+```
+
+---
+
+## /getbyhash
+
+The `/getbyhash` endpoint retrieves a transaction based on the given hash (if one exists at that hash).
+
+```
+POST /transaction/getbyhash
+```
+
+### Parameters
+
+#### hash <span style="color:red">required</span>
+
+A string value that represents a blockhash. This string can be either 64 or 66 characters long, if the string is 66 characters the first two characters should be `0x`.
+
+### Response:
+
+Retrieves a transaction object.
+
+## /getbyhashbatch
+
+The `/getbyhashbatch` endpoint retrieves a list of transactions based on the list of given hashes.
+
+```
+POST /transaction/getbyhashbatch
+```
+
+### Parameters
+
+#### hash array <span style="color:red">required</span>
+
+A list of string values that represent transaction hashes. These strings can be either 64 or 66 characters long, if the string is 66 characters the first two characters should be `0x`.
+
+### Response:
+
+Retrieves a list of transaction objects.
+
+## /broadcast
+
+The `/broadcast` endpoint sends a signed and valid transaction to the aleo network.
+
+```
+POST /transaction/broadcast
+```
+
+### Parameters
+
+#### raw transaction <span style="color:red">required</span>
+
+A 1950 character long string that represents an valid signed raw transaction.
+
+### Response:
+
+A transaction hash of the posted transaction.
+
+## /validate
+
+The `/validate` validates wether the given transaction is valid on the current aleo network.
+
+```
+POST /transaction/validate
+```
+
+### Parameters
+
+#### raw transaction <span style="color:red">required</span>
+
+A 1950 character long string that represents an valid signed raw transaction.
+
+### Response:
+
+A boolean value (true or false), wether the transaction is valid or not.


### PR DESCRIPTION
Adding the documentations for the block explorer API, i have tried to follow your file naming schemes. The documentation uses just basic .md formatting.

Currently everything resides in a single doc for each api page (the models that are returned as well as the api endpoints)

the api's documented are
Authentication
* createapikey

block
* getbest
* getbyheight 
* getbyheightrange
* getbyhash

transaction
* getbyhash
* getbyhashbatch
* broadcast
* validate

metrics
* get
* graph