### PR TITLE
Order some keywords alphabetically

### DIFF
--- a/documentation/developer/language/13_lexical.md
+++ b/documentation/developer/language/13_lexical.md
@@ -40,8 +40,8 @@ address
 as
 bool
 circuit
-const
 console
+const
 else
 false
 field
@@ -55,8 +55,8 @@ i64
 i128
 if
 import
-input
 in
+input
 let
 mut
 return


### PR DESCRIPTION
Two pairs of contiguous keywords were not in alphabetical order. This commit puts them in order.

(Side note: the list of keywords is essentially alphabetical, with the slight exceptions that (i) `Self` comes just after `self` in the list and (ii) `i8`, `i16`, ..., `u8`, `u16`, ... are in numeric order. I believe that both exceptions are quite reasonable and make things clearer than following a strictly string-alphabetical order.)