### PR TITLE
[Grammar] Deprecate context annotation

### DIFF
--- a/documentation/developer/additional_material/00_style.md
+++ b/documentation/developer/additional_material/00_style.md
@@ -34,7 +34,8 @@ function foo() {
     // ...
 }
 
-test function test_foo() {
+@test
+function test_foo() {
     // ...
 }
 ```
@@ -51,8 +52,8 @@ function foo() {
     // ...
 }
 
-
-test function test_foo() {
+@test
+function test_foo() {
     // ...
 }
 ```

--- a/documentation/developer/cli/05_test.md
+++ b/documentation/developer/cli/05_test.md
@@ -21,5 +21,5 @@ The results of the test compilation and the constraint system will be printed:
     Finished Tests passed in 10 milliseconds. 2 passed; 0 failed;
 ```
 
-A new circuit is generated for each test. Inputs from the [**test context annotation**](../language/12_tests.md#test-context-annotation)
+A new circuit is generated for each test. Inputs from the [**test annotation**](../language/12_tests.md#annotation-arguments)
 are loaded after the test circuit builds successfully.

--- a/documentation/developer/language/00_flying_tour.md
+++ b/documentation/developer/language/00_flying_tour.md
@@ -20,7 +20,8 @@ function square(a: u32, b: u32) -> bool {
     return a * a == b
 }
 
-test function test_square() {
+@test
+function test_square() {
     let a: u32 = 5;
     let b: u32 = 25;
     
@@ -55,10 +56,10 @@ The `square` function is called by `main` with private inputs `a` and `b` which 
 
 A naive way to test `square` would be to execute `leo run` several times on different inputs and check the output of the program each time.
 
-Luckily, we can write [unit tests](12_tests.md) in Leo using the `test function` syntax and run them using [`leo test`](../cli/05_test.md). 
+Luckily, we can write [unit tests](12_tests.md) in Leo using the `@test` syntax and run them using [`leo test`](../cli/05_test.md). 
 In `test_square` we can sanity check our code without having to load in private inputs from a file every time. 
-Want to upgrade your test function into an integration test? 
-In Leo you can add a [test context annotation](12_tests.md#test-context-annotation) that loads different sets of private inputs to make your test suite even more robust.
+Want to upgrade your unit test into an integration test? 
+In Leo you can provide [arguments](12_tests.md#test-annotation-arguments) that load different sets of private inputs to make your test suite even more robust.
 
 The last line of `test_square` uses the console function `console.assert`. 
 This function along with `console.log`, `console.debug`, and `console.error` provide developers with tools that are run without

--- a/documentation/developer/language/01_layout.md
+++ b/documentation/developer/language/01_layout.md
@@ -49,7 +49,7 @@ function main() {
 ### Tests
 
 Each [test](12_tests.md) function generates new constraints for an isolated test circuit.
-The input to a test can be specified with the [context annotation](12_tests.md#test-context-annotation).
+The input to a test can be specified with the [test annotation](12_tests.md#annotation-arguments).
 Tests are executed with the Leo [test command](../cli/05_test.md).
 
 ```leo
@@ -57,7 +57,8 @@ function square(a: u32) -> u32 {
     return a * a
 }
 
-test function test_square() {
+@test
+function test_square() {
     let expected: u32 = 25;
 
     let actual = square(5u32);

--- a/documentation/developer/language/11_console.md
+++ b/documentation/developer/language/11_console.md
@@ -15,7 +15,8 @@ function square(a: u32) -> u32 {
     return a * a
 }
 
-test function test_square() {
+@test
+function test_square() {
     let expected: u32 = 25;
 
     let actual = square(5u32);

--- a/documentation/developer/language/12_tests.md
+++ b/documentation/developer/language/12_tests.md
@@ -3,14 +3,23 @@ id: tests
 title: Writing Tests
 ---
 
-Use the `test` keyword to define tests in a leo program.
+## Annotations
+
+Annotations provide additional metadata to a definition in Leo.
+
+:::info
+Annotations are a work in progress. Currently only the `@test` annotation is supported.
+:::
+
+Use the `@test` annotation to define tests in a leo program.
 
 ```leo
 function main(a: u32) -> u32 {
     return a
 }
 
-test function test_main() {
+@test
+function test_main() {
     let a = 1u32;
 
     let res = main(a);
@@ -18,7 +27,8 @@ test function test_main() {
     console.assert(res == 1u32);
 }
 
-test function test_ne() {
+@test
+function test_ne() {
     console.assert(1u8 != 0u8);
 }
 ```
@@ -40,13 +50,14 @@ function main() {
 ```
 
 ## The Anatomy of a Test Function
-Inside the Leo `test function` signature you have access to all `imports`, `circuits`, and `functions` in the current scope.
+Inside the Leo `@test` function body you have access to all `imports`, `circuits`, and `functions` in the current scope.
 ```leo title="src/main.leo"
 function add_one(a: u32) -> u32 {
     return a + 1
 }
 
-test function test_add_one() {
+@test
+function test_add_one() {
     let one = 1u32;
     let two = 2u32;
 
@@ -83,7 +94,8 @@ function add_one(a: u32) -> u32 {
     return a + 1
 }
 
-test function test_add_one() {
+@test
+function test_add_one() {
     let one = 1u32;
     let two = 2u32;
 
@@ -114,7 +126,7 @@ leo test
       Done Tests failed in 10 milliseconds. 0 passed; 1 failed;
 ```
 
-As expected, the test now fails. The console output tells us the exact line where the assert failed.
+As expected, the test now fails. The console output tells us the exact line where the assertion failed.
 
 ### Failing Test Compilation 
 
@@ -125,7 +137,8 @@ function add_one(a: u32) -> u32 {
     return a + 1
 }
 
-test function test_add_one() {
+@test
+function test_add_one() {
     let one = 1u32;
     let two = 2u32;
 
@@ -154,27 +167,23 @@ Add a second `one` as input to the function call to `add_one`.
 As expected, the test fails telling us that we incorrectly provided 2 inputs to the `add_one` function.
 Since we failed before running the circuit, there is no output about the constraint system.
 
-## Annotations
+## Annotation Arguments
 
-Annotations provide additional metadata to a definition in Leo.
+One or more arguments can be passed into an annotation using parenthesis `()`
 
-:::info
-Annotations are a work in progress. Currently only the `@context` test annotation is supported
-:::
-
-### Test Context Annotation
-The context annotation takes one argument that will be used as the file name for input and output files.
+### Test Annotation Arguments
+The `@test` annotation can take one argument that will be used as the file name for input and output files.
 For integration tests, one can invoke [`.in`](08_inputs.md#program-inputs) and [`.state`](../programming_model/00_model.md#state-file) files to load the correct input and state as follows:
  
 For example, one could invoke it as any of the following examples:
 ```leo
-@context(production) //  production.in, production.state, production.out
-test function token_withdraw() {
+@test(production) //  production.in, production.state, production.out
+function token_withdraw() {
     ...
 }
 
-@context(custom)   //  custom.in, custom.state, custom.out
-test function token_withdraw() {
+@test(custom)   //  custom.in, custom.state, custom.out
+function token_withdraw() {
     ...
 }
 ```
@@ -191,15 +200,15 @@ a: u32 = 1;
 // empty
 ```
 
-Use the test context annotation to load the production input environment into the program test.
+Use the test annotation to load the production input environment into the program test.
 
 ```leo title="src/main.leo"
 function add_one(a: u32) -> u32 {
     return a + 1
 }
 
-@context(production)
-test function test_add_one_production(a: u32) { // `a` is provided by the `production.in` file
+@test(production)
+function test_add_one_production(a: u32) { // `a` is provided by the `production.in` file
     let expected = a + 1;
 
     let actual = add_one(a);

--- a/documentation/developer/programming_model/00_model.md
+++ b/documentation/developer/programming_model/00_model.md
@@ -86,7 +86,7 @@ The return function of main will automatically write to the output registers in 
 Intermediate runtime state will automatically be passed from one record's output register to the next record's input register.
 
 :::info
-To see how to load register files into tests, checkout [**Writing Tests**](../language/12_tests.md#test-context-annotation).
+To see how to load register files into tests, checkout [**Writing Tests**](../language/12_tests.md#annotation-arguments).
 :::
 
 ## State
@@ -149,7 +149,7 @@ The `[state_leaf]` section defines state leaf transition information that is enc
 The state leaf section must be defined below the private `[[private]]` section.
 
 :::info
-To see how to load state files into tests, checkout [**Writing Tests**](../language/12_tests.md#test-context-annotation)
+To see how to load state files into tests, checkout [**Writing Tests**](../language/12_tests.md#annotation-arguments)
 :::
 
 ## Where Register and State Files are Stored


### PR DESCRIPTION
Updates Leo syntax to be up to date with https://github.com/AleoHQ/leo/pull/561