### PR TITLE
Update 05_operators.md

### DIFF
--- a/documentation/developer/language/05_operators.md
+++ b/documentation/developer/language/05_operators.md
@@ -51,7 +51,7 @@ Operators will prioritize evaluation according to:
 |            Operator           | Associativity |
 |:-----------------------------:|:-------------:|
 |              `!`              |               |
-|              `**`             | left to right |
+|              `**`             | right to left |
 |             `*` `/`           | left to right |
 |             `+` `-`           | left to right |
 |  `==` `!=` `<` `>` `<=` `>=`  | left to right |


### PR DESCRIPTION
Normally exponentiation is right-to-left associativity and I verified this with a Leo example 2 ** 1 ** 2 ==> 2.