### PR TITLE
Fix typo

### DIFF
--- a/documentation/aleo/concepts/01_programs.md
+++ b/documentation/aleo/concepts/01_programs.md
@@ -51,7 +51,7 @@ function main() {
 ### Program ID
 
 Each program has a unique a **program ID** that is produced from the
-hash of the [verifying key](#verifying-key). This program ID is used to indicate the program that was ran in the
+hash of the [verifying key](#verifying-key). This program ID is used to indicate the program that was run in the
 consumption or production of [records](02_records.md).
 
 ### Program Input


### PR DESCRIPTION
Or alternatively we could write 'program that ran'.