### PR TITLE
Nitpicking suggestion for uniformity

### DIFF
--- a/documentation/developer/language/00_flying_tour.md
+++ b/documentation/developer/language/00_flying_tour.md
@@ -42,7 +42,7 @@ r: u32 = 0;
 ```
 ## 1. Data Types
 
-Leo supports boolean, unsigned integer, signed integer, field, group element, and address [data types](03_types.md). Data types in Leo 
+Leo supports boolean, unsigned integer, signed integer, field, group, and address [data types](03_types.md). Data types in Leo 
 must be explicitly stated `let a: u32 = 5`;
 Collections of data types can be created in the form of static [arrays and tuples](04_arrays_and_tuples.md).
 


### PR DESCRIPTION
Here we are essentially saying 'boolean data type', 'unsigned integer data type', .., 'field data type', 'group (element) data type', ...

So it seems fine to just say 'group'.

Alternatively, '..., field element, group element, ...' if we want to refer to the values of the types. E.g. the boolean type consists of booleans, the field type consists of field elements, the group type consists of group elements.