### PR TITLE
Improve description of tuple indices

### DIFF
--- a/documentation/developer/language/04_arrays_and_tuples.md
+++ b/documentation/developer/language/04_arrays_and_tuples.md
@@ -169,7 +169,7 @@ function main() -> u32 {
 
 # Tuples
 Leo supports tuples of other data types.
-Tuple values are accessed with a dot `.` the index must be a `u32`.
+Tuple values are accessed with a dot `.` the index must be a non-negative numeric literal.
 
 ```leo
 let a = (true, true);


### PR DESCRIPTION
As written, it may mislead into thinking that an expression of type `u32` is allowed, as for arrays, but that's not the case for tuples.