### PR TITLE
Proposed change to table

### DIFF
--- a/documentation/developer/language/05_operators.md
+++ b/documentation/developer/language/05_operators.md
@@ -54,7 +54,8 @@ Operators will prioritize evaluation according to:
 |              `**`             | left to right |
 |             `*` `/`           | left to right |
 |             `+` `-`           | left to right |
-|  `==` `!=` `<` `>` `<=` `>=`  | left to right |
+|       `<` `>` `<=` `>=`       |               |
+|           `==` `!=`           | left to right |
 |              `&&`             | left to right |
 |             \| \|             | left to right |
 | `=` `+=` `-=` `*=` `/=` `**=` |               |


### PR DESCRIPTION
Since the ordering operators < <= > >= return booleans, but these operators are not defined on booleans, associativity does not really apply to them.

The current grammar rule does not support associations of these operators:
```
ordering-expression = additive-expression
                    / additive-expression "<" additive-expression
                    / additive-expression ">" additive-expression
                    / additive-expression "<=" additive-expression
                    / additive-expression ">=" additive-expression
```