### PR TITLE
Fix display of OR operator in docs

### DIFF
--- a/documentation/developer/language/05_operators.md
+++ b/documentation/developer/language/05_operators.md
@@ -57,7 +57,7 @@ Operators will prioritize evaluation according to:
 |       `<` `>` `<=` `>=`       |               |
 |           `==` `!=`           | left to right |
 |              `&&`             | left to right |
-|            `\|\|`             | left to right |
+|            <code>&#124;&#124;</code>             | left to right |
 | `=` `+=` `-=` `*=` `/=` `**=` |               |
 
 ### Parentheses


### PR DESCRIPTION
See here: https://developer.aleo.org/developer/language/operators#logical-operators
Note that the Github markdown render does not need this change, this only happens on the docs.
Note: I didn't format the table nicely again.