### PR TITLE
Add char and string literal to documentation

### DIFF
--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -55,31 +55,31 @@ let b: field = 21888242871839275222246405745257275088548364400416034343698204186
 
 ## Char type
 
-Leo has `char` type for using characters.
+Leo has a `char` type for using characters.
 ```leo
 let c = 'c';
 let d: char = '¢';
 let e = '😉'; // emojis are also supported
 ```
 
-It is also possible to define characters in Rust like manner, allowed escapes are:
+It is also possible to define characters in a Rust-like manner; allowed escapes are:
 ```leo
 let unicode_escape = '\u{11FA}';
 let ascii = '\x1F';
 let escape = '\\';
 ```
 
-Character specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
+A more comprehensive character specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
 
 :::warn
-Some emojis (such as this one: `🤷🏿‍♀️`) can not be represented as a single character because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple emojis which are viewed as one. Most common groups of emojis of this kind are: flags and emojis with skin tone.
+Some emojis (such as this one: `🤷🏿‍♀️`) cannot be represented as a single character because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple emojis which are viewed as one. Most common groups of emojis of this kind are: flags and emojis with skin tone.
 :::
 
 ### Character escapes
 
 - *Unicode escapes* - use `\u{}` escape with 1-6 HEX digits in curly braces for unicode character numbers.
 - *ASCII HEX escapes* - use `\x` escape followed by 2 HEX digits with max value of 127 (`\x7F`).
-- *Escapes* - following symbols can be escaped: `\0`, `\\`, `\"`, `\'`, `\n`, `\r` and `\t`.
+- *Simple escapes* - the following symbols can be escaped: `\0`, `\\`, `\"`, `\'`, `\n`, `\r` and `\t`.
 
 
 ## Group Elements

--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -55,7 +55,7 @@ let b: field = 21888242871839275222246405745257275088548364400416034343698204186
 
 ## Char type
 
-Leo has a `char` type for using characters.
+Leo has a `char` type for using characters. Char contains 1 Unicode code point.
 ```leo
 let c = 'c';
 let d: char = '¢';
@@ -72,8 +72,18 @@ let escape = '\\';
 A more comprehensive character specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
 
 :::warn
-Some emojis (such as this one: `🤷🏿‍♀️`) cannot be represented as a single character because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple emojis which are viewed as one. Most common groups of emojis of this kind are: flags and emojis with skin tone.
+Some emojis (such as this one: `🤷🏿‍♀️`) and diacritics cannot be represented as a single char because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple Unicode code points which are viewed as one symbol.
 :::
+
+Examples of Unicode sequences:
+```leo
+let c: char = 'у́'; // illegal
+let c: [1; char] = "у́"; // illegal
+let c: [2; char] = "у́"; // correct
+
+let e: char = "🤷🏿‍♀️"; // illegal
+let e: [char; 5] = "🤷🏿‍♀️"; // correct
+```
 
 ### Character escapes
 

--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -53,6 +53,35 @@ let a = 1field;
 let b: field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
 ```
 
+## Char type
+
+Leo has `char` type for using characters.
+```leo
+let c = 'c';
+let d: char = '¢';
+let e = '😉'; // emojis are also supported
+```
+
+It is also possible to define characters in Rust like manner, allowed escapes are:
+```leo
+let unicode_escape = '\u{11FA}';
+let ascii = '\x1F';
+let escape = '\\';
+```
+
+Character specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
+
+:::warn
+Some emojis (such as this one: `🤷🏿‍♀️`) can not be represented as a single character because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple emojis which are viewed as one. Most common groups of emojis of this kind are: flags and emojis with skin tone.
+:::
+
+### Character escapes
+
+- *Unicode escapes* - use `\u{}` escape with 1-6 HEX digits in curly braces for unicode character numbers.
+- *ASCII HEX escapes* - use `\x` escape followed by 2 HEX digits with max value of 127 (`\x7F`).
+- *Escapes* - following symbols can be escaped: `\0`, `\\`, `\"`, `\'`, `\n`, `\r` and `\t`.
+
+
 ## Group Elements
 The set of affine points on the elliptic curve passed into the Leo compiler forms a group.
 Leo supports this set as a primitive data type. Group elements are special since their values can be defined as 

--- a/documentation/developer/language/04_arrays_and_tuples.md
+++ b/documentation/developer/language/04_arrays_and_tuples.md
@@ -99,7 +99,7 @@ let f = [true, false || true, true];
 
 ## Arrays of Chars as Strings
 
-Leo features string literal for defining arrays of chars. Strings are not a type but a simple way of defining
+Leo features string literals for defining arrays of chars. Strings are not a type but a simple way of defining
 arrays of characters. 
 
 ```leo
@@ -108,7 +108,7 @@ let hello = "hello";
 let h: char = hello[0];
 ```
 
-It is also possible to use string literal for comparing values (just like arrays):
+It is also possible to use string literals for comparing values (just like arrays):
 
 ```leo
 function main(hello: [char; 5]) -> bool {

--- a/documentation/developer/language/04_arrays_and_tuples.md
+++ b/documentation/developer/language/04_arrays_and_tuples.md
@@ -1,7 +1,7 @@
 ---
 id: arrays_and_tuples
 title: Arrays
-sidebar_label: Arrays and Tuples
+sidebar_label: Arrays, Strings and Tuples
 ---
 
 ## Indexing
@@ -9,7 +9,7 @@ Arrays and tuples in Leo are zero indexed.
 
 ## Array Types
 Leo supports arrays of all types:
-arrays of integers, arrays of field elements, arrays of circuits, etc.
+arrays of integers, arrays of field elements, arrays of circuits, arrays of chars, etc.
 An array type is defined by both the type and the number of its elements:
 for example, the type of arrays of `u8` integers of length 3
 is different from
@@ -95,6 +95,25 @@ let e = [5field; 2];
 
 // initialize a boolean array
 let f = [true, false || true, true];
+```
+
+## Arrays of Chars as Strings
+
+Leo features string literal for defining arrays of chars. Strings are not a type but a simple way of defining
+arrays of characters. 
+
+```leo
+let hello_world: [char; 12] = "hello world!";
+let hello = "hello";
+let h: char = hello[0];
+```
+
+It is also possible to use string literal for comparing values (just like arrays):
+
+```leo
+function main(hello: [char; 5]) -> bool {
+    return hello == "hello";
+} 
 ```
 
 ## Multi-dimensional Arrays


### PR DESCRIPTION
Closes https://github.com/AleoHQ/leo/issues/985.
Part of Strings epic: https://github.com/AleoHQ/leo/issues/929.

- Adds `char` type description to Leo types.
- Adds string literal to arrays section
- Renames "Arrays and Tuples" -> "Arrays, Strings and Tuples"