### PR TITLE
Add more details on Unicode sequences.

### DIFF
--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -55,41 +55,52 @@ let b: field = 21888242871839275222246405745257275088548364400416034343698204186
 
 ## Char type
 
-Leo has a `char` type for using characters. Char contains 1 Unicode code point.
+Leo has a `char` type for using characters. Each `char` contains 1 Unicode code point.
 ```leo
 let c = 'c';
 let d: char = '¢';
 let e = '😉'; // emojis are also supported
 ```
 
-It is also possible to define characters in a Rust-like manner; allowed escapes are:
+It is also possible to define characters in a Rust-like manner; some allowed escapes are:
 ```leo
 let unicode_escape = '\u{11FA}';
 let ascii = '\x1F';
 let escape = '\\';
 ```
 
-A more comprehensive character specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
+A more comprehensive specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
 
 :::warn
-Some emojis (such as this one: `🤷🏿‍♀️`) and diacritics cannot be represented as a single char because they are actually [unicode sequences](https://unicode.org/Public/emoji/13.1/emoji-sequences.txt) - sequences of multiple Unicode code points which are viewed as one symbol.
+When a user-perceived character is represented by more than one Unicode code point,
+it can not be represented by a single Leo `char`.  Furthermore, since the length of an
+array must be declared, you will need to know how many Unicode code points are used
+when you want a literal string containing such a character.
+Here are some examples:
+ - `אֶ` // Hebrew alef with segol
+ - `у́` // Cyrillic u with accent
+ - `🤷🏿‍♀️` // shrug with various modifiers
+
+If you are not sure how many code points a given user-perceived character requires,
+you can use a tool such as [Richard Cook's Namelist tool](http://linguistics.berkeley.edu/~rscook/cgi/nameslistsearch.html)
+or [r12a's List characters](https://r12a.github.io/app-listcharacters/).
 :::
 
 Examples of Unicode sequences:
 ```leo
 let c: char = 'у́'; // illegal
 let c: [1; char] = "у́"; // illegal
-let c: [2; char] = "у́"; // correct
+let c: [2; char] = "у́"; // correct, same as "\u{443}\u{301}"
 
-let e: char = "🤷🏿‍♀️"; // illegal
-let e: [char; 5] = "🤷🏿‍♀️"; // correct
+let e: char = '🤷🏿‍♀️'; // illegal
+let e: [char; 5] = "🤷🏿‍♀️"; // correct, same as "\u{1F937}\u{1F3FF}\u{200D}\u{2640}\u{FE0F}"
 ```
 
 ### Character escapes
 
 - *Unicode escapes* - use `\u{}` escape with 1-6 HEX digits in curly braces for unicode character numbers.
 - *ASCII HEX escapes* - use `\x` escape followed by 2 HEX digits with max value of 127 (`\x7F`).
-- *Simple escapes* - the following symbols can be escaped: `\0`, `\\`, `\"`, `\'`, `\n`, `\r` and `\t`.
+- *Simple escapes* - the following symbols can be escaped: `\0` (meaning `\x00`), `\\`, `\"`, `\'`, `\n`, `\r` and `\t`.
 
 
 ## Group Elements

--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -73,7 +73,7 @@ A more comprehensive specification is described in [Leo RFC 1](https://github.co
 
 :::warn
 When a user-perceived character is represented by more than one Unicode code point,
-it can not be represented by a single Leo `char`.  Furthermore, since the length of an
+it cannot be represented by a single Leo `char`.  Furthermore, since the length of an
 array must be declared, you will need to know how many Unicode code points are used
 when you want a literal string containing such a character.
 Here are some examples:


### PR DESCRIPTION
Note, I do not know how the :::warn works.  It does not render in github markdown, so I can't preview it.  If it does not support bulleted items or hyperlinks, it will need to be restructured.