### PR TITLE
Update 03_types.md

### DIFF
--- a/documentation/developer/language/03_types.md
+++ b/documentation/developer/language/03_types.md
@@ -71,7 +71,7 @@ let escape = '\\';
 
 A more comprehensive specification is described in [Leo RFC 1](https://github.com/AleoHQ/leo/blob/master/docs/rfc/001-initial-strings.md).
 
-:::warn
+:::warning
 When a user-perceived character is represented by more than one Unicode code point,
 it cannot be represented by a single Leo `char`.  Furthermore, since the length of an
 array must be declared, you will need to know how many Unicode code points are used


### PR DESCRIPTION
The warning box did not come out right.  I think it is because it should be `:::warning` instead of `:::warn`.
I don't know how to render it to check so maybe a reviewer who knows can try it.