### PR TITLE
Fix documentation error and other changes

### DIFF
--- a/documentation/developer/language/04_arrays_and_tuples.md
+++ b/documentation/developer/language/04_arrays_and_tuples.md
@@ -51,7 +51,7 @@ let arr: [u32; 4] = [3, 9, 27, 81];
 
 let first_two = arr[..2]; // = [3, 9]
 
-let middle_two = arr[1..=2]; // = [9, 27]
+let middle_two = arr[1..3]; // = [9, 27]
 
 let last_two = arr[2..]; // = [27, 81]
 ```


### PR DESCRIPTION
Incorrect example, and a few small changes made after recommendations from Leo team members. The switch from [0,1, 2, 3] to [3, 9, 27, 81] is to avoid any possible confusion from having index values being the same as the actual values.