### PR TITLE
Updated records, transitions, and execute transaction 

### DIFF
--- a/documentation/00_getting_started.md
+++ b/documentation/00_getting_started.md
@@ -1,6 +1,6 @@
 ---
 id: getting_started
-title: Getting Started
+title: Hello World
 sidebar_label: Getting Started
 ---
 

--- a/documentation/00_getting_started.md
+++ b/documentation/00_getting_started.md
@@ -1,6 +1,6 @@
 ---
 id: getting_started
-title: Hello World
+title: Getting Started
 sidebar_label: Getting Started
 ---
 

--- a/documentation/aleo/08_tooling.md
+++ b/documentation/aleo/08_tooling.md
@@ -88,7 +88,7 @@ git clone https://github.com/julesdesmit/aleo.vim ~/.vim/pack/plugins/start/aleo
 ```
 
 
-#### [Vundle][v]
+#### Vundle
 
 
 ```vim
@@ -138,7 +138,7 @@ NeoBundle 'julesdesmit/aleo.vim'
 ```
 
 
-[v]: https://github.com/gmarik/vundle
+[//]: # ([v]: https://github.com/gmarik/vundle)
 
 [p]: https://github.com/tpope/vim-pathogen
 

--- a/documentation/concepts/02_records.md
+++ b/documentation/concepts/02_records.md
@@ -7,20 +7,20 @@ sidebar_label: Records
 A **record** is a fundamental data structure for encoding user assets and application state.
 
 Each account record contains information that specifies the record owner, its stored value, and its application state. 
-An Aleo account can create a [transaction](03_transactions.md) to consume a record and produce a new record in its place.
-Records on Aleo are encrypted to the record owner address, ensuring that all records on Aleo are fully private.
+Records in Aleo are consumed and newly created from a [transition](04_transitions.md) function. A [transaction](03_transactions.md) will store multiple transitions, each of which is responsible for the consumption and creation of its individual records. 
+Optionally, if the `visibility` of the record is `private`, it can be encrypted using the owner's address secret key. 
 
 ## Components of a Record
 
 An Aleo record is serialized in the following format:
 
-| Parameter |          Type          |                    Description                    |
-|:---------:|:----------------------:|:-------------------------------------------------:|
-|  `owner`  |        address         |          The owner of the program record          |
-|  `gates`  |          u64           | The Aleo balance (in gates) of the program record |
-|  `data`   | Map<Identifier, Entry> |                 The program data                  |
-|  `nonce`  |         group          |          The nonce of the program record          |
-
+|  Parameter   |          Type          |                              Description                              |
+|:------------:|:----------------------:|:---------------------------------------------------------------------:|
+|    `apk`     |        address         |       The address public key of the owner of the program record       |
+|   `gates`    |          u64           |           The Aleo balance (in gates) of the program record           |
+|    `data`    | Map<Identifier, Entry> | A data payload containing arbitrary application-dependent information |
+|   `nonce`    |         group          |             The serial number nonce of the program record             |
+| `visibility` |          enum          |  The record's visibility, which can either be `public` or `private`   |
 ### Owner
 
 ```
@@ -29,7 +29,7 @@ aleo1r0dry2tlhjt0yplctz85692kjpqsadn7xgxsmrehkasykjxynypqza3fpl
 The **record owner** is an [account address](00_accounts.md#account-address),
 and specifies the party who is authorized to spend the record.
 
-### gates
+### Gates
 
 ```
 4130
@@ -50,11 +50,11 @@ The **record data** encodes arbitrary application information.
 ```
 3024738992072387217402876176731225730589877991873828351104009809002984426287group
 ```
+The **serial number nonce** is used to create a unique identifier for each record,
+and is computed via a `PRF` evaluation of the address secret key `ask` of the `owner` and the record's serial number.
 
-## Advanced Topics
 
-### Record Encryption
-
-When a record is produced in a transaction, it is verifiably encrypted in the transaction and stored on the ledger.
-This enables users to securely and privately transfer record data and value between one another over the public network. 
+### (Optional) Record Encryption
+A record which has a `visibility` of `private` is verifiably encrypted in the transition and stored on the ledger.
+This enables users to securely and privately transfer record data and values between one another over the public network. 
 Only the sender and receiver with their corresponding account view keys are able to decrypt these records.

--- a/documentation/concepts/03_transactions.md
+++ b/documentation/concepts/03_transactions.md
@@ -28,10 +28,8 @@ The transaction deployment publishes an Aleo program to the network.
 |    `program`     | object  |                             The program                              |
 | `verifying_keys` | mapping | The mapping of function names to their verifying key and certificate |
 
-### Execute Transaction
+### Execute Transaction 
 The transaction execution represents a call to an Aleo program.
-
-#### Execute Transaction
 
 |    Parameter     |          Type           |                                                       Description                                                       |
 |:----------------:|:-----------------------:|:-----------------------------------------------------------------------------------------------------------------------:|

--- a/documentation/concepts/03_transactions.md
+++ b/documentation/concepts/03_transactions.md
@@ -33,12 +33,12 @@ The transaction execution represents a call to an Aleo program.
 
 #### Execute Transaction
 
-|    Parameter     |  Type  |              Description               |
-|:----------------:|:------:|:--------------------------------------:|
-|      `type`      | string |        The type of transaction         |
-|       `id`       | string |         The ID of transaction          |
-|   `execution`    | object |     The execution transaction info     |
-| `additional_fee` | object | The additional fee for the transaction |
+|    Parameter     |          Type           |                                                       Description                                                       |
+|:----------------:|:-----------------------:|:-----------------------------------------------------------------------------------------------------------------------:|
+|      `type`      |         string          |                                  The type of transaction, either `Deploy` or `Execute`                                  |
+|       `id`       |         string          |                    The ID of transaction, computed via the Merkle Tree Digest of the transition IDs                     |
+|  `transitions`   | Map<Identifier, Object> | A mapping of transition IDs to the corresponding [transition](04_transitions.md) objects contained in the transaction.  |
+| `additional_fee` |           i64           |                                         The additional fee for the transaction                                          |
 
 #### Execution Info
 

--- a/documentation/concepts/03_transactions.md
+++ b/documentation/concepts/03_transactions.md
@@ -28,7 +28,7 @@ The transaction deployment publishes an Aleo program to the network.
 |    `program`     | object  |                             The program                              |
 | `verifying_keys` | mapping | The mapping of function names to their verifying key and certificate |
 
-### Execute Transaction 
+### Execute Transaction
 The transaction execution represents a call to an Aleo program.
 
 |    Parameter     |          Type           |                                                       Description                                                       |

--- a/documentation/concepts/04_transitions.md
+++ b/documentation/concepts/04_transitions.md
@@ -7,15 +7,16 @@ sidebar_label: Transitions
 ## Components of a Transition
 An Aleo transition is serialized in the following format:
 
-|    Parameter    |  Type  |        Description        |
-|:---------------:|:------:|:-------------------------:|
-|      `id`       | string |     The transition id     |
-|  `program_id`   | string |      The program id       |
-| `function_name` | string |     The function name     |
-|    `inputs`     | array  |   The transition inputs   |
-|    `outputs`    | array  |  The transition outputs   |
-|   `finalize`    | array  |  The inputs for finalize  |
-|     `proof`     | string |   The transition proof    |
-|      `tpk`      | string | The transition public key |
-|      `tcm`      | string | The transition commitment |
-|      `fee`      |  i64   |      The network fee      |
+|    Parameter    |         Type         |                                         Description                                         |
+|:---------------:|:--------------------:|:-------------------------------------------------------------------------------------------:|
+|      `id`       | finite field element |                                      The transition id                                      |
+|  `program_id`   |        string        |                                       The program id                                        |
+| `function_name` |        string        |                                      The function name                                      |
+|    `inputs`     |  array of `Input`s   |  The transition `Input`s, which can be a `constant`, `public`, `private`, or `inputRecord`  |
+|    `outputs`    |  array of `Output`s  | The transition `Output`s, which can be a `constant`, `public`, `private`, or `outputRecord` |
+|   `finalize`    |        array         |                                   The inputs for finalize                                   |
+|     `proof`     |    group element     |                                    The transition proof                                     |
+|      `tpk`      |    group element     |                                  The transition public key                                  |
+|      `tcm`      | finite field element |                                  The transition commitment                                  |
+|      `fee`      |         i64          |                                       The network fee                                       |
+An `inputRecord` is a tuple consisting of a serial numbera nd a `tag`, while an `outputRecord` consists of a record commitment, checksum, an a record ciphertext.

--- a/documentation/concepts/04_transitions.md
+++ b/documentation/concepts/04_transitions.md
@@ -7,16 +7,22 @@ sidebar_label: Transitions
 ## Components of a Transition
 An Aleo transition is serialized in the following format:
 
-|    Parameter    |         Type         |                                         Description                                         |
-|:---------------:|:--------------------:|:-------------------------------------------------------------------------------------------:|
-|      `id`       | finite field element |                                      The transition id                                      |
-|  `program_id`   |        string        |                                       The program id                                        |
-| `function_name` |        string        |                                      The function name                                      |
-|    `inputs`     |  array of `Input`s   |  The transition `Input`s, which can be a `constant`, `public`, `private`, or `inputRecord`  |
-|    `outputs`    |  array of `Output`s  | The transition `Output`s, which can be a `constant`, `public`, `private`, or `outputRecord` |
-|   `finalize`    |        array         |                                   The inputs for finalize                                   |
-|     `proof`     |    group element     |                                    The transition proof                                     |
-|      `tpk`      |    group element     |                                  The transition public key                                  |
-|      `tcm`      | finite field element |                                  The transition commitment                                  |
-|      `fee`      |         i64          |                                       The network fee                                       |
-An `inputRecord` is a tuple consisting of a serial numbera nd a `tag`, while an `outputRecord` consists of a record commitment, checksum, an a record ciphertext.
+|    Parameter    |         Type         |                                                                        Description                                                                        |
+|:---------------:|:--------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
+|      `id`       | finite field element |                         The transition id, which is computed via the Merkle tree digest formed from the `Input` and `Output` IDs                          |
+|  `program_id`   |        string        |                          The program ID, which is associated with a verification key on a globally maintained map on the ledger.                          |
+| `function_name` |        string        |                                    The function name, which is used to compute a `function_id` using the `program_id`.                                    |
+|    `inputs`     |  array of `Input`s   |                                 The transition `Input`s, which can be a `constant`, `public`, `private`, or `inputRecord`                                 |
+|    `outputs`    |  array of `Output`s  |                                The transition `Output`s, which can be a `constant`, `public`, `private`, or `outputRecord`                                |
+|   `finalize`    |        array         |                                                                  The inputs for finalize                                                                  |
+|     `proof`     |    group element     | The transition proof, used to verify the correctness of the program execution associated to `function_name` within the program associated to `program_id` |
+|      `tpk`      |    group element     |                    The transition public key, which is used to verify the digital signature provided by the `owner` in a `transaction`                    |
+|      `tcm`      | finite field element |                                                                 The transition commitment                                                                 |
+|      `fee`      |         i64          |                                                       The network fee associated to the transition.                                                       |
+
+#### Input Record
+An `inputRecord` is a tuple consisting of a serial number and a `tag`. Recall that serial numbers are posted onto the ledger to announce that previously unspent records have now been spent. Each record has an associated `tag` which
+is used to keep track of records which are spendable by the user.
+
+#### Output Record
+An `outputRecord` consists of a record commitment, checksum, an a record ciphertext. 

--- a/documentation/concepts/04_transitions.md
+++ b/documentation/concepts/04_transitions.md
@@ -21,8 +21,8 @@ An Aleo transition is serialized in the following format:
 |      `fee`      |         i64          |                                                       The network fee associated to the transition.                                                       |
 
 #### Input Record
-An `inputRecord` is a tuple consisting of a serial number and a `tag`. Recall that serial numbers are posted onto the ledger to announce that previously unspent records have now been spent. Each record has an associated `tag` which
-is used to keep track of records which are spendable by the user.
+An `inputRecord` is a tuple consisting of a `serial_number` and a `tag`. Recall that since the serial number is disclosed on the ledger, this publicly announces the record which is being spent. 
+Recall that serial numbers are posted onto the ledger to announce that previously unspent records have now been spent. Each record has an associated `tag` which is used to keep track of records which are spendable by the user. A tag is computed via `tag` = CRH.Eval(`sk_tag`, `record_commitment`).
 
 #### Output Record
-An `outputRecord` consists of a record commitment, checksum, an a record ciphertext. 
+An `outputRecord` consists of a `record_commitment`, `checksum`, an a `record_ciphertext`. A `record_commitment` is computed via Pedersen.Commit(`pp`, `apk` || `data` || `nonce` || `gates` ; r). The `record_encryption` is computed via SymmEnc.Eval(`pp`, `apk` || `data` || `nonce` || `gates` ; r) and the checksum, used to verify the integrity of the record commitment, is computed via `record_commitment` = CRH.Eval(`record_encryption`).  


### PR DESCRIPTION
- Updated documentation on records (https://github.com/AleoHQ/snarkVM/tree/testnet3/console/program/src/data/record) , specifically the parameters: address of the owner, data, nonce, and added visibility field to table. Also elaborated on section about optional encryption. 
- Updated documentation on transitions (https://github.com/AleoHQ/snarkVM/tree/testnet3/synthesizer/src/block/transition) specifically the parameters: id, program_id, function_name, inputs, outputs, proof, tpk, fee. Added section describing Input (https://github.com/AleoHQ/snarkVM/blob/testnet3/synthesizer/src/block/transition/input/mod.rs) and Output (https://github.com/AleoHQ/snarkVM/tree/testnet3/synthesizer/src/block/transition/output) Records 
- Fixed table on Execute transactions (https://github.com/AleoHQ/snarkVM/tree/testnet3/synthesizer/src/block/transaction), updating id parameter and adding transitions Map parameter. 