### PR TITLE
Update 08_auction.md

### DIFF
--- a/documentation/leo/08_auction.md
+++ b/documentation/leo/08_auction.md
@@ -52,7 +52,7 @@ See `./run.sh` for an example of how to run the program as different parties.
 The [Aleo SDK](https://github.com/AleoHQ/leo/tree/testnet3) provides a command line interface for generating new accounts.
 To generate a new account, run
 ```
-leo account new
+aleo account new
 ```
 
 ### Using an input file.


### PR DESCRIPTION
aleo account new cmd corrected.

`leo account new` is not working gives this error:
![image](https://github.com/AleoHQ/welcome/assets/52135949/405375e8-f3cd-4bc8-932d-df634ec16530)

`aleo account new` works perfectly
