### PR TITLE
Update 08_auction.md instructions for clarity

### DIFF
--- a/documentation/leo/08_auction.md
+++ b/documentation/leo/08_auction.md
@@ -217,8 +217,6 @@ Have the auctioneer finish the auction.
     }
 ```
 
-Swap in the private key and address of the auctioneer to program.json.
-
 Call the `finish` transition function with the winning `Bid` record.
 
 ```bash 


### PR DESCRIPTION
This PR removes one line from the Auction instructions for clarity. The deleted line prompts user to "Swap in the private key and address of the auctioneer to program.json." in Step 4, when they just did this in Step 3. 