### PR TITLE
Document `group::GEN` in Leo.

### DIFF
--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -72,11 +72,17 @@ Group elements are special since their values can be defined from the x-coordina
 `1group`. The group type keyword `group` must be used when specifying a group value.
 
 ```leo
-let b: group = 0group; // the zero of the group
+let b: group = 0group; // the point with 0 x-coordinate
 
-let a: group = 1group; // the group generator
+let a: group = 1group; // the point with 1 x-coordinate
 
-let c: group = 2group; // 2 * the group generator
+let c: group = 2group; // the point with 2 x-coordinate
+```
+
+The aforementioned generator point can be obtained via a constant associated to the `group` type.
+
+```leo
+let g: group = group::GEN; // the group generator
 ```
 
 ### Scalar Elements
@@ -456,7 +462,7 @@ Sets the `addr` entry as `current_value + 1u64` in `counter`.
 
 ## For Loops
 
-For Loops are declared as `for {variable: type} in {lower bound}..{upper bound}`. Unsigned integer 
+For Loops are declared as `for {variable: type} in {lower bound}..{upper bound}`. Unsigned integer
 types `u8`, `u16`, and `u32` are recommended for loop variable types. The lower bound must be
 less than the upper bound. Nested loops are supported.
 

--- a/documentation/leo/04_operators.md
+++ b/documentation/leo/04_operators.md
@@ -50,6 +50,7 @@ The Leo operators compile down to [Aleo instructions opcodes](../aleo/04_opcodes
 | [sub_wrapped](#sub_wrapped)                 | Wrapping subtraction operation      |
 | [ternary](#ternary)                         | Ternary select operation            |
 | [xor](#xor)                                 | XOR operation                       |
+| [group::GEN](#groupgen)                     | Group generator                     |
 
 ## Table of cryptographic Operators
 | Name                                                        | Description                                       |
@@ -2380,6 +2381,32 @@ Performs a XOR operation on integer (bitwise) or boolean `first` and `second`, s
 | `U32`     | `U32`     | `U32`       |
 | `U64`     | `U64`     | `U64`       |
 | `U128`    | `U128`    | `U128`      |
+
+[Back to Top](#table-of-standard-operators)
+***
+
+### `group::GEN`
+
+```leo
+let g: group = group::GEN; // true
+```
+
+#### Description
+
+Returns the generator of the algebraic group that the `group` type consists of.
+
+The compilation of Leo is based on an elliptic curve, whose points form a group,
+and on a specified point on that curve, which generarates a subgroup, whose elements form the type `group`.
+
+This is a constant, not a function. Thus, it takes no inputs, and just returns an output.
+
+It is an associated constant, whose name is `GEN` and whose associated type is `group`.
+
+#### Supported Types
+
+| Destination |
+|-------------|
+| `Group`     |
 
 [Back to Top](#table-of-standard-operators)
 ***

--- a/documentation/leo/04_operators.md
+++ b/documentation/leo/04_operators.md
@@ -2388,7 +2388,7 @@ Performs a XOR operation on integer (bitwise) or boolean `first` and `second`, s
 ### `group::GEN`
 
 ```leo
-let g: group = group::GEN; // true
+let g: group = group::GEN; // the group generator
 ```
 
 #### Description


### PR DESCRIPTION
Closes #191.

Also fixes pre-existing code comments that were out of date.
