### PR TITLE
Update high-level grammar of Aleo instructions.

### DIFF
--- a/documentation/aleo/06_grammar.md
+++ b/documentation/aleo/06_grammar.md
@@ -4,83 +4,177 @@ title: Aleo Instructions Grammar
 sidebar_label: Grammar
 ---
 
-This chapter briefly describes the Aleo instructions grammar.
-A more advanced language specification written in ABNF format can be found [here](07_abnf.md).
+This chapter contains a high-level grammar of Aleo instructions.
+A more detailed ABNF grammar can be found [here](https://github.com/AleoHQ/grammars).
 
 ```
-program = *import title 1*definition
+program = *import
+          "program" program-id ";"
+          1*( mapping / struct / record / closure / function )
 import = "import" program-id ";"
-title = "program" program-id ";"
-program-id = identifier [ "." identifier ]
-definition = mapping / struct / record / function / closure
-mapping = "mapping" identifier ":" mapping-key mapping-value
+mapping = "mapping" identifier ":"
+          mapping-key
+          mapping-value
 mapping-key = "key" identifier "as" finalize-type ";"
 mapping-value = "value" identifier "as" finalize-type ";"
-struct = "struct" identifier ":" 1*struct-component
-struct-component = identifier "as" plain-type ";"
+struct = "struct" identifier ":" 1*tuple
+tuple = identifier "as" plaintext-type ";"
 record = "record" identifier ":"
-         "owner" "as" ( "address.private" / "address.public" )
-         "microcredits" "as" ( "u64.private" / "u64.public" )
-         *record-entry
-record-entry = identifier "as" entry-type ";"
-closure = "closure" identifier ":" *input 1*instruction *output
-function = "function" identifier ":" *input *instruction *output [ finalize-command finalize ]
-finalize = "finalize" identifier ":" *finalize-input 1*command *finalize-output
-finalize-command = "finalize" *operand ";"
-input = "input" base-register "as" in-out-type ";"
-output = "output" register "as" in-out-type ";"
+         "owner" "as" ( "address.public" / "address.private" ) ";"
+         *entry
+entry = identifier "as" entry-type ";"
+closure = "closure" identifier ":"
+          *closure-input
+          1*instruction
+          *closure-output
+closure-input = "input" register "as" register-type ";"
+closure-output = "output" operand "as" register-type ";"
+function = "function" identifier ":"
+           *function-input
+           *instruction
+           *function-output
+           [ finalize-command finalize ]
+function-input = "input" register "as" value-type ";"
+function-output = "output" operand "as" value-type ";"
+finalize = "finalize" identifier ":"
+           *finalize-input
+           1*command
+           *finalize-output
 finalize-input = "input" register "as" finalize-type ";"
-finalize-output = "output" register "as" finalize-type ";"
-command = decrement / increment / instruction
-decrement = "decrement" identifier "[" operand "]" "by" operand ";"
-increment = "increment" identifier "[" operand "]" "by" operand ";"
-instruction = unary / binary / ternary / assert / cast / call
-unary = unary-op operand "into" register ";"
-binary = binary-op 2operand "into" register ";"
-ternary = ternary-op 3operand "into" register ";"
-assert = assert-op 2operand ";"
-unary-op = "abs" / "abs.w" / "double" / "inv"
-         / "neg" / "not" / "square" / "sqrt"
-         / "hash.bhp" ( "256" / "512" / "768" / "1024" )
-         / "hash.ped" ( "64" / "128" )
-         / "hash.psd" ( "2" / "4" / "8" )
-binary-op = "add" / "add.w" / "sub" / "sub.w" / "mul" / "mul.w"
-          / "div" / "div.w" / "rem" / "rem.w" / "pow" / "pow.w"
-          / "shl" / "shl.w" / "shr" / "shr.w"
-          / "and" / "or" / "xor" / "nand" / "nor"
-          / "gt" / "gte" / "lt" / "lte" / "is.eq" / "is.neq"
-          / "commit.bhp" ( "256" / "512" / "768" / "1024" )
-          / "commit.ped" ( "64" / "128" )
+finalize-output = "output" operand "as" finalize-type ";"
+finalize-command = "finalize" *( operand ) ";"
+command = contains
+        / get
+        / get-or-use
+        / set
+        / remove
+        / random
+        / position
+        / branch
+        / instruction
+contains = "contains" identifier "[" operand "]" "into" register ";"
+get = "get" identifier "[" operand "]" "into" register ";"
+get-or-use = "get.or_use" identifier "[" operand "]" operand "into" register ";"
+set = "set" operand "into" identifier "[" operand "]" ";"
+remove = "remove" identifier "[" operand "]" ";"
+random  = "rand.chacha" *2( operand ) "into" register "as" literal-type ";"
+label = identifier
+position = "position" label ";"
+branch-op = "branch.eq" / "branch.neq"
+branch = branch-op operand operand label ";"
+instruction = ( unary
+              / binary
+              / ternary
+              / is
+              / assert
+              / commit
+              / hash
+              / cast
+              / call )
+              ";"
+unary = unary-op ( operand ) "into" register
+unary-op = "abs" / "abs.w"
+         / "double"
+         / "inv"
+         / "neg"
+         / "not"
+         / "square"
+         / "sqrt"
+binary = binary-op 2( operand ) "into" register
+binary-op = "add" / "add.w"
+          / "sub" / "sub.w"
+          / "mul" / "mul.w"
+          / "div" / "div.w"
+          / "rem" / "rem.w"
+          / "mod"
+          / "pow" / "pow.w"
+          / "shl" / "shl.w"
+          / "shr" / "shr.w"
+          / "and"
+          / "or"
+          / "xor"
+          / "nand"
+          / "nor"
+          / "gt"
+          / "gte"
+          / "lt"
+          / "lte"
+ternary = ternary-op 3( operand ) "into" register
 ternary-op = "ternary"
+is = is-op operand operand "into" register
+is-op = "is.eq" / "is.neq"
+assert = assert-op operand operand
 assert-op = "assert.eq" / "assert.neq"
-cast = "cast" 1*operand "into" register "as" register-type ";"
-call = "call" callee *operand "into" *registers ";"
-callee = identifier / external
-operand = literal / register
-literal = "aleo1" 58( lowercase / digit )   ; address
-        / "true" / "false"                  ; boolean
-        / %x22 *string-element %x22         ; string "..."
-        / [ "-" ] numeral arithmetic-type   ; arithmetic
-string-element = %x0-21 / #x23-5b / %x5d-10ffff ; anything but " or \
-               / %x5c.22 ; escape for "
-               / %x5c.5c ; escape for \
-register = base-register *( "." identifier )
-base-register = %"r" numeral
-arithmetic-type = "field" / "group" / "scalar"
-                / "u8" / "u16" / "u32" / "u64" / "u128"
-                / "i8" / "i16" / "i32" / "i64" / "i128"
-primitive-type = arithmetic-type / "address" / "bool" / "string"
-plain-type = primitive-type / identifier
-entry-type = plain-type ( ".constant" / ".public" / ".private" )
-record-type = ( identifier / external ) ".record"
-register-type = plain-type / record-type
-in-out-type = entry-type / record-type
-finalize-type = ( plain-type ".public" ) / record-type
-external = program-id "/" identifier
+commit = commit-op operand operand "into" register "as" ( address-type / field-type / group-type )
+commit-op = "commit.bhp" ( "256" / "512" / "768" / "1024" )
+          / "commit.ped" ( "64" / "128" )
+hash = hash-op operand "into" register "as" ( arithmetic-type / address-type )
+hash-op = "hash.bhp" ( "256" / "512" / "768" / "1024" )
+        / "hash.ped" ( "64" / "128" )
+        / "hash.psd" ( "2" / "4" / "8" )
+        / "hash_many.psd" ( "2" / "4" / "8" )
+cast = cast-op 1*( operand ) "into" register "as" cast-destination
+cast-op = "cast"
+cast-destination = register-type / "group.x" / "group.y"
+call = "call" ( locator / identifier ) *( operand ) "into" 1*( register )
+operand = literal
+        / "group::GEN"
+        / register-access
+        / program-id
+        / "self.caller"
+        / "block.height"
+literal = arithmetic-literal
+        / address-literal
+        / boolean-literal
+arithmetic-literal = integer-literal
+                   / field-literal
+                   / group-literal
+                   / scalar-literal
+integer-literal = signed-literal / unsigned-literal
+signed-literal = [ "-" ] 1*( digit *"_" ) signed-type
+unsigned-literal = [ "-" ] 1*( digit *"_" ) unsigned-type
+field-literal = [ "-" ] 1*( digit *"_" ) field-type
+group-literal = [ "-" ] 1*( digit *"_" ) group-type
+scalar-literal = [ "-" ] 1*( digit *"_" ) scalar-type
+address-literal = "aleo1" 1*( address-char *"_" )
+address-char = "0" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9"
+             / "a" / "c" / "d" / "e" / "f" / "g" / "h" / "j"
+             / "k" / "l" / "m" / "n" / "p" / "q" / "r" / "s"
+             / "t" / "u" / "v" / "w" / "x" / "y" / "z"
+boolean-literal = "true" / "false"
+register = "r" 1*digit
+register-access = register *( "." identifier )
+unsigned-type = "u8" / "u16" / "u32" / "u64" / "u128"
+signed-type = "i8" / "i16" / "i32" / "i64" / "i128"
+integer-type = unsigned-type / signed-type
+field-type = "field"
+group-type = "group"
+scalar-type = "scalar"
+arithmetic-type = integer-type / field-type / group-type / scalar-type
+address-type = "address"
+boolean-type = "boolean"
+literal-type = arithmetic-type / address-type / boolean-type / string-type
+plaintext-type = literal-type / identifier
+value-type = plaintext-type ".constant"
+           / plaintext-type ".public"
+           / plaintext-type ".private"
+           / identifier ".record"
+           / locator ".record"
+finalize-type = plaintext-type ".public"
+              / identifier ".record"
+              / locator ".record"
+entry-type = plaintext-type ( ".constant" / ".public" / ".private" )
+register-type = locator ".record"
+              / identifier ".record"
+              / plaintext-type
 digit = "0"-"9"
-numeral = 1*digit
-uppercase = "A"-"Z"
-lowercase = "a"-"z"
-letter = uppercase / lowercase
-identifier = (letter / "_") *( letter / digit / "_" ) ; but not a keyword
+uppercase-letter = "A"-"Z"
+lowercase-letter = "a"-"z"
+letter = uppercase-letter / lowercase-letter
+identifier = letter *( letter / digit / "_" )
+lowercase-identifier = lowercase-letter *( lowercase-letter / digit / "_" )
+program-name = lowercase-identifier
+program-domain = lowercase-identifier
+program-id = program-name "." program-domain
+locator = program-id "/" identifier
 ```


### PR DESCRIPTION
Also reference ABNF grammar directly in `grammars` repo.

This is just for the high-level (slightly simplified) grammar. The chapter on the ABNF grammar is no updated yet by this PR.