### PR TITLE
Feat/signature verify

### DIFF
--- a/documentation/aleo/03_language.md
+++ b/documentation/aleo/03_language.md
@@ -79,7 +79,7 @@ function main:
 
 ### Signatures
 
-Aleo uses a Schnorr signatures scheme to sign messages with the address private key.
+Aleo uses a Schnorr signatures scheme to sign messages with an Aleo private key.
 Signatures can be verified in Aleo instructions using the [`sign.verify`](./04_opcodes.md#signverify) instruction.
 
 ```aleo

--- a/documentation/aleo/03_language.md
+++ b/documentation/aleo/03_language.md
@@ -77,6 +77,15 @@ function main:
     input r0: address.private;
 ```
 
+### Signatures
+
+Aleo uses a Schnorr signatures scheme to sign messages with the address private key.
+Signatures can be verified in Aleo instructions using the [`sign.verify`](./04_opcodes.md#signverify) instruction.
+
+```aleo
+sign.verify sign069ju4e8s66unu25celqycvsv3k9chdyz4n4sy62tx6wxj0u25vqp58hgu9hwyqc63qzxvjwesf2wz0krcvvw9kd9x0rsk4lwqn2acqhp9v0pdkhx6gvkanuuwratqmxa3du7l43c05253hhed9eg6ppzzfnjt06fpzp6msekdjxd36smjltndmxjndvv9x2uecsgngcwsc2qkns4afd r1 r2 into r3;
+```
+
 ## Layout of an Aleo Program
 
 An Aleo program contains declarations of a [Program ID](#programid), [Imports](#import), [Functions](#function), [Closures](#closure), [Structs](#struct), [Records](#record),

--- a/documentation/aleo/04_opcodes.md
+++ b/documentation/aleo/04_opcodes.md
@@ -74,6 +74,7 @@ The following lists show the standard and cryptographic opcodes supported by Ale
 | [hash.psd2](#hashpsd2)                             | Poseidon hash with input rate 2   |
 | [hash.psd4](#hashpsd4)                             | Poseidon hash with input rate 4   |
 | [hash.psd8](#hashpsd8)                             | Poseidon hash with input rate 8   |
+| [sign.verify](#signverify)                         | Verify a Schnorr signature        |
 
 ## Specification
 
@@ -1468,6 +1469,28 @@ Computes the truncated remainder of `first` divided by `second`, wrapping around
 | `U32`  | `U32`  | `U32`       |
 | `U64`  | `U64`  | `U64`       |
 | `U128` | `U128` | `U128`      |
+
+***
+
+### `sign.verify`
+
+[Back to Top](#table-of-standard-opcodes)
+
+#### Description
+
+Verifies the signature `first` against the address public key `second` and the message `third`, storing the outcome in `destination`.
+
+#### Example Usage
+
+```aleo
+sign.verify r0 r1 r2 into r3;
+```
+
+#### Supported Types
+
+| First       | Second    | Third     | Destination |
+|-------------|-----------|-----------|-------------|
+| `Signature` | `Address` | `Message` | `Boolean`   |
 
 ***
 

--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -104,7 +104,7 @@ let receiver: address = aleo1ezamst4pjgj9zfxqq0fwfj8a4cjuqndmasgata3hggzqygggnyf
 
 Aleo uses a Schnorr signatures scheme to sign messages with an Aleo private key.
 Signatures in Leo have their own type `signature` and can be declared as literals `sign069ju4e8s66unu25celqycvsv3k9chdyz4n4sy62tx6wxj0u25vqp58hgu9hwyqc63qzxvjwesf2wz0krcvvw9kd9x0rsk4lwqn2acqhp9v0pdkhx6gvkanuuwratqmxa3du7l43c05253hhed9eg6ppzzfnjt06fpzp6msekdjxd36smjltndmxjndvv9x2uecsgngcwsc2qkns4afd`.  
-Signatures can be verified in Leo using the [`sign.verify`](./04_operators.md#signatureverify) instruction.
+Signatures can be verified in Leo using the [`signature::verify` or `s.verify`](./04_operators.md#signatureverify) operators.
 
 ```leo
 program test.aleo {

--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -100,6 +100,34 @@ These semantics will be accompanied by a standard library in a future sprint.
 let receiver: address = aleo1ezamst4pjgj9zfxqq0fwfj8a4cjuqndmasgata3hggzqygggnyfq6kmyd4;
 ```
 
+### Signatures
+
+Aleo uses a Schnorr signatures scheme to sign messages with an Aleo private key.
+Signatures in Leo have their own type `signature` and can be declared as literals `sign069ju4e8s66unu25celqycvsv3k9chdyz4n4sy62tx6wxj0u25vqp58hgu9hwyqc63qzxvjwesf2wz0krcvvw9kd9x0rsk4lwqn2acqhp9v0pdkhx6gvkanuuwratqmxa3du7l43c05253hhed9eg6ppzzfnjt06fpzp6msekdjxd36smjltndmxjndvv9x2uecsgngcwsc2qkns4afd`.  
+Signatures can be verified in Leo using the [`sign.verify`](./04_operators.md#signatureverify) instruction.
+
+```leo
+program test.aleo {
+
+    struct foo {
+        a: u8,
+        b: scalar
+    }
+
+    transition verify_field(s: signature, a: address, v: field) {
+        let first: bool = signature::verify(s, a, v);
+        let second: bool = s.verify(a, v);
+        assert_eq(first, second);
+    }
+
+    transition verify_foo(s: signature, a: address, v: foo) {
+        let first: bool = signature::verify(s, a, v);
+        let second: bool = s.verify(a, v);
+        assert_eq(first, second);
+    }
+}
+```
+
 ## Layout of a Leo Program
 
 A Leo program contains declarations of a [Program Scope](#program-scope), [Imports](#import)

--- a/documentation/leo/04_operators.md
+++ b/documentation/leo/04_operators.md
@@ -71,6 +71,7 @@ The Leo operators compile down to [Aleo instructions opcodes](../aleo/04_opcodes
 | [Poseidon2::hash_to_destination](#poseidon2hash_to_destination)         | Poseidon hash with input rate 2   |
 | [Poseidon4::hash_to_destination](#poseidon4hash_to_destination)         | Poseidon hash with input rate 4   |
 | [Poseidon8::hash_to_destination](#poseidon8hash_to_destination)         | Poseidon hash with input rate 8   |
+| [signature::verify](#signatureverify)                                   | Verify a signature                |
 
 ## Specification
 
@@ -990,6 +991,29 @@ Computes the truncated remainder of `first` divided by `second`, wrapping around
 | `U32`  | `U32`  | `U32`       |
 | `U64`  | `U64`  | `U64`       |
 | `U128` | `U128` | `U128`      |
+
+[Back to Top](#table-of-standard-operators)
+***
+
+### `signature::verify`
+
+```leo
+transition verify_field(s: signature, a: address, v: field) {
+    let first: bool = signature::verify(s, a, v);
+    let second: bool = s.verify(a, v);
+    assert_eq(first, second);
+}
+```
+
+#### Description
+
+Verifies that the signature `first` was signed by the address `second` with respect to the field `third`, storing the outcome in `destination`.
+
+#### Supported Types
+
+| First       | Second    | Third     | Destination |
+|-------------|-----------|-----------|-------------|
+| `Signature` | `Address` | `Message` | `Boolean`   |
 
 [Back to Top](#table-of-standard-operators)
 ***


### PR DESCRIPTION
# Overview

- [x] adds documentation for `sign.verify` opcode in Aleo instructions.
- [x] adds documentation for `signature::verify` and `s.verify` operations in Leo.

## Example Aleo instructions code
```
sign.verify sign069ju4e8s66unu25celqycvsv3k9chdyz4n4sy62tx6wxj0u25vqp58hgu9hwyqc63qzxvjwesf2wz0krcvvw9kd9x0rsk4lwqn2acqhp9v0pdkhx6gvkanuuwratqmxa3du7l43c05253hhed9eg6ppzzfnjt06fpzp6msekdjxd36smjltndmxjndvv9x2uecsgngcwsc2qkns4afd r1 r2 into r3;
```

## Example Leo code
```rust
    transition verify_field(s: signature, a: address, v: field) {
        let first: bool = signature::verify(s, a, v);
        let second: bool = s.verify(a, v);
        assert_eq(first, second);
    }
```

## Linked Issues
Closes #268 

