### PR TITLE
Update Create Aleo App Install Script & Tutorial Title

### DIFF
--- a/documentation/sdk/create-aleo-app/00_app_installation.md
+++ b/documentation/sdk/create-aleo-app/00_app_installation.md
@@ -21,21 +21,11 @@ npm create aleo-app@latest
 
 Then follow the prompts!
 
-You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold an Aleo + React project, run:
-
-```bash
-# npm 6.x
-npm create aleo-app@latest aleo-project --template react
-
-# npm 7+, extra double-dash is needed:
-npm create aleo-app@latest aleo-project -- --template react
-```
-
 Currently supported template presets include:
-- `vanilla` (javascript)
-- `react`
-
-You can use `.` for the project name to scaffold in the current directory.
+- `react` + `javascript`
+- `react` + `javascript` + `leo`
+- `node` + `javascript`
+- `vanilla (javascript)`
 
 ## More Information
 

--- a/documentation/sdk/create-aleo-app/01_create_aleo_app.md
+++ b/documentation/sdk/create-aleo-app/01_create_aleo_app.md
@@ -62,6 +62,7 @@ Write down your private key, view key, and public address in a safe place. Treat
 Once you have your account, use our faucet to get some Aleo credits! We have a faucet by text and one via Discord.
 <!-- markdown-link-check-disable -->
 Head to our [faucet page](https://faucet.aleo.org/) and follow the instructions there. 
+<!-- markdown-link-check-enable -->
 
 After the credits have been disbursed to your address, note your transaction ID down.
 

--- a/documentation/sdk/create-aleo-app/01_create_aleo_app.md
+++ b/documentation/sdk/create-aleo-app/01_create_aleo_app.md
@@ -1,7 +1,7 @@
 ---
 id: tutorial
-title: Create Aleo App - React Leo Tutorial
-sidebar_label: React + Leo Tutorial
+title: Create Aleo App - React + JS + Leo Tutorial
+sidebar_label: React + JS + Leo Tutorial
 ---
 
 <a href="https://www.npmjs.com/package/create-aleo-app"> <img alt="Create Aleo App" src="https://img.shields.io/npm/l/create-aleo-app?label=NPM%20-%20Create-Aleo-App&labelColor=green&color=blue" /></a>

--- a/documentation/sdk/create-aleo-app/01_create_aleo_app.md
+++ b/documentation/sdk/create-aleo-app/01_create_aleo_app.md
@@ -59,7 +59,13 @@ Write down your private key, view key, and public address in a safe place. Treat
 
 ### Faucet
 
-Once you have your account, use our faucet to get some Aleo credits! If you haven’t already, join our [Discord server](https://discord.gg/aleohq) and use the `#faucet` channel. You can send only one request every 20 minutes and can only request 50 credits per hour. Once you send a faucet request, Discord will start a thread under the faucet channel with your request.
+Once you have your account, use our faucet to get some Aleo credits! We have a faucet by text and one via Discord.
+
+Head to our [faucet page](https://faucet.aleo.org/) and follow the instructions there. 
+
+After the credits have been disbursed to your address, note your transaction ID down.
+
+You can also join our [Discord server](https://discord.gg/aleohq) and use the `#faucet` channel if texting isn't working. You can send only one request every 20 minutes and can only request 50 credits per hour. Once you send a faucet request, Discord will start a thread under the faucet channel with your request.
 
 Format:
 

--- a/documentation/sdk/create-aleo-app/01_create_aleo_app.md
+++ b/documentation/sdk/create-aleo-app/01_create_aleo_app.md
@@ -60,7 +60,7 @@ Write down your private key, view key, and public address in a safe place. Treat
 ### Faucet
 
 Once you have your account, use our faucet to get some Aleo credits! We have a faucet by text and one via Discord.
-
+<!-- markdown-link-check-disable -->
 Head to our [faucet page](https://faucet.aleo.org/) and follow the instructions there. 
 
 After the credits have been disbursed to your address, note your transaction ID down.


### PR DESCRIPTION
1. Added templates and templates to be in combination format (framework + variant)
2. Removed older version of node examples and `--template` options, didn't seem to work when tested locally
3. Adding the "framework + variant" syntax to the tutorial documentation so people aren't confused and can match up what we're using with the tutorial.
4. added faucet by text instructions