### PR TITLE
Add Leo Array Syntax Documentation

### DIFF
--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -276,6 +276,57 @@ record token {
 }
 ```
 
+### Array
+
+Leo supports static arrays. The Array data type is declared as `[type; length]`. Arrays cannot be empty nor modified.
+
+Arrays can only support constant accesses (the index must be a constant value). The accessor value must be a constant integer.
+
+Arrays can contain primitive data types, structs, or arrays. Structs and Records can also contain Arrays.
+
+Arrays can be iterated over using a for loop.
+
+```leo
+// Initalize a boolean array of length 4
+let arr: [bool; 4] = [true, false, true, false];
+
+// Nested Array
+let nested: [[bool; 2]; 2] = [[true, false], [true, false]];
+
+// Array of Records
+struct bar {
+    data: u8,
+}
+
+// Access the field of a Record within an Array
+transition foo(a: [bar; 8]) -> u8 {
+    return a[0u8].data;
+}
+
+// Struct that contains an Array
+struct bat {
+    data: [u8; 8],
+}
+
+// Record that contains an Array
+record floo {
+    owner: address,
+    data: [u8; 8],
+}
+
+// Declare a Mapping that contains an Array value
+mapping data: address => [bool; 8];
+
+// Iterate over an Array using a for loop and sum the values within
+transition sum_with_loop(a: [u64; 4]) -> u64 {
+    let sum: u64 = 0u64;
+    for i: u8 in 0u8..4u8 {
+        sum += a[i];
+    }
+    return sum;
+}
+```
+
 ### Transition Function
 
 Transition functions in Leo are declared as `transition {name}() {}`.

--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -278,9 +278,9 @@ record token {
 
 ### Array
 
-Leo supports static arrays. The Array data type is declared as `[type; length]`. Arrays cannot be empty nor modified.
+Leo supports static arrays. Arrays are declared as `[type; length]`. Arrays cannot be empty nor modified.
 
-Arrays can only support constant accesses (the index must be a constant value). The accessor value must be a constant integer.
+Arrays only support constant accesses (the index must be a constant value). The accessor value must be a constant integer.
 
 Arrays can contain primitive data types, structs, or arrays. Structs and Records can also contain Arrays.
 

--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -282,7 +282,7 @@ Leo supports static arrays. Arrays are declared as `[type; length]`. Arrays cann
 
 Arrays only support constant accesses (the index must be a constant value). The accessor value must be a constant integer.
 
-Arrays can contain primitive data types, structs, or arrays. Structs and Records can also contain Arrays.
+Arrays can contain primitive data types, structs, or arrays. Structs and records can also contain arrays.
 
 Arrays can be iterated over using a for loop.
 
@@ -300,26 +300,26 @@ struct bar {
 
 let arr_of_structs: [bar; 2] = [bar { data: 1u8 }, bar { data: 2u8 }];
 
-// Access the field of a Struct within an Array
+// Access the field of a struct within an array
 transition foo(a: [bar; 8]) -> u8 {
     return a[0u8].data;
 }
 
-// Struct that contains an Array
+// Struct that contains an array
 struct bat {
     data: [u8; 8],
 }
 
-// Record that contains an Array
+// Record that contains an array
 record floo {
     owner: address,
     data: [u8; 8],
 }
 
-// Declare a Mapping that contains an Array value
+// Declare a mapping that contains an array value
 mapping data: address => [bool; 8];
 
-// Iterate over an Array using a for loop and sum the values within
+// Iterate over an array using a for loop and sum the values within
 transition sum_with_loop(a: [u64; 4]) -> u64 {
     let sum: u64 = 0u64;
     for i: u8 in 0u8..4u8 {

--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -293,12 +293,14 @@ let arr: [bool; 4] = [true, false, true, false];
 // Nested Array
 let nested: [[bool; 2]; 2] = [[true, false], [true, false]];
 
-// Array of Records
+// Array of Structs
 struct bar {
     data: u8,
 }
 
-// Access the field of a Record within an Array
+let arr_of_structs: [bar; 2] = [bar { data: 1u8 }, bar { data: 2u8 }];
+
+// Access the field of a Struct within an Array
 transition foo(a: [bar; 8]) -> u8 {
     return a[0u8].data;
 }

--- a/documentation/leo/09_cheatsheet.md
+++ b/documentation/leo/09_cheatsheet.md
@@ -50,7 +50,12 @@ struct message {
 }
 ```
 
-## 6. Transitions
+## 6. Arrays
+```leo
+let arr: [bool; 2] = [true, false];
+```
+
+## 7. Transitions
 ```leo
 transition mint_public(
     public receiver: address,
@@ -58,14 +63,14 @@ transition mint_public(
 ) -> token { /* Your code here */ }
 ```
 
-## 7. Functions
+## 8. Functions
 ```leo
 function compute(a: u64, b: u64) -> u64 {
     return a + b;
 }
 ```
 
-## 8. Inline Functions
+## 9. Inline Functions
 ```leo
 inline foo(
     a: field,
@@ -84,7 +89,7 @@ inlines can only call inlines.
 Direct/indirect recursive calls are not allowed
 
 
-## 9. For Loops
+## 10. For Loops
 ```leo
 let count: u32 = 0u32;
 
@@ -93,7 +98,7 @@ for i: u32 in 0u32..5u32 {
 }
 ```
 
-## 10. Mappings
+## 11. Mappings
 ```leo
 mapping balances: address => u64;
 
@@ -104,7 +109,7 @@ let set_bal: () = Mapping::set(balances, receiver, 100u64);
 let remove_bal: () = Mapping::remove(balances, receiver);
 ```
 
-## 11. Commands
+## 12. Commands
 ```leo
 transition matches(height: u32) { 
     return then finalize(height); 
@@ -129,7 +134,7 @@ assert_neq(a, b); // assert a and b are not equal
 ```
 
 
-## 12. Operators
+## 13. Operators
 ```leo
 let sum: u64 = a + b; // arithmetic addition
 let diff: u64 = a - b; // arithmetic subtraction


### PR DESCRIPTION
Adds Array Documentation for Leo language docs

Explanation, examples and syntax based on documentation and test cases implemented in https://github.com/AleoHQ/leo/pull/2888