### PR TITLE
Fixed errror in docs - Section - Installation snarkOS

### DIFF
--- a/documentation/testnet/getting_started/01_installation.md
+++ b/documentation/testnet/getting_started/01_installation.md
@@ -37,7 +37,7 @@ The following are **minimum** requirements to run an Aleo node:
  - **OS**: 64-bit architectures only, latest up-to-date for security
     - Clients: Ubuntu 20.04, macOS Ventura or later, Windows 11 or later
     - Provers: Ubuntu 20.04, macOS Ventura or later
-    - Validators: Ubuntu 20.04, macOS Ventura or later
+    - Validators: Ubuntu 20.04
  - **CPU**: 64-bit architectures only
     - Clients: 16-cores
     - Provers: 32-cores (64-cores preferred)


### PR DESCRIPTION
MacOS is not officially supported for Validators

See: https://github.com/AleoHQ/snarkOS/pull/3040#issuecomment-1913735755