### PR TITLE
Plugins for Leo - Documentation Update

### DIFF
--- a/documentation/aleo/07_tooling.md
+++ b/documentation/aleo/07_tooling.md
@@ -17,12 +17,14 @@ If you do not see your favorite editor on this list, please reach out on [GitHub
 3. [Intellij](#intellij).
 
 ## Sublime Text
+
 ![](./images/sublime.png)  
 Download the editor here: https://www.sublimetext.com/download.
 Aleo instructions support for Sublime's LSP plugin is provided through a language-server.
+
 ### Install
 
-1. Install [LSP](https://packagecontrol.io/packages/LSP) and [LSP-aleo-developer](https://packagecontrol.io/packages/LSP-aleo-developer) from Package Control.
+1. Install [LSP](https://packagecontrol.io/packages/LSP) and [LSP-leo](https://packagecontrol.io/packages/LSP-leo) from Package Control.
 2. Restart Sublime.
 
 ### Usage
@@ -30,27 +32,29 @@ Aleo instructions support for Sublime's LSP plugin is provided through a languag
 Follow these steps to toggle the `Aleo instructions` syntax highlighter.
 
 1. Open `Sublime Text`.
-2. From Preferences > Select Color Scheme... > LSP-aleo-developer
+2. From Preferences > Select Color Scheme... > LSP-leo
 
 ## VSCode
+
 ![](./images/vscode.png)
 Download the editor here: https://code.visualstudio.com/download.
 
 ### Install
 
-Install [Leo for VSCode](https://marketplace.visualstudio.com/items?itemName=aleohq.leo-extension) from VSCode marketplace.   
-The correct extension ID is `aleohq.leo-extension`.
+1. Install [Leo for VSCode](https://marketplace.visualstudio.com/items?itemName=aleohq.leo-extension) from VSCode marketplace.   
+2. The correct extension ID is `aleohq.leo-extension`.
 
 ### Usage
 
 1. Open `VSCode`.
-2. From Preferences > Color Theme... > Aleo Theme
+2. Go to Settings > Extensions or use the left side panel Extensions button to enable the Leo plugin.
 
-## Intellij
+## IntelliJ
 
 ![](./images/intellij.png)
 Download the editor here: https://www.jetbrains.com/idea/download/.
 
 ### Install
 
-Install the [Aleo Developer Plugin](https://plugins.jetbrains.com/plugin/19890-aleo-developer) from JetBrains marketplace.   
+1. Download the [Aleo Developer Plugin](https://plugins.jetbrains.com/plugin/19890-aleo-developer) from JetBrains marketplace.
+2. Click on Plugins on the left side panel > gear icon > Install Plugin from Disk > Select the downloaded zip file


### PR DESCRIPTION
On https://leo-lang.org/, there are links to download Leo syntax highlighting plugins for Sublime, IntelliJ, and VSCode.

The documentation on how to install these plugins are here: https://developer.aleo.org/leo/tooling

Some of the language and several links were out of date. This PR updates it to the latest.

Separately installed from scratch for all three code editors on MacOSX to test functionality ✅