### PR TITLE
Add docs for empty arrays

### DIFF
--- a/documentation/guides/07_devnet.md
+++ b/documentation/guides/07_devnet.md
@@ -143,7 +143,7 @@ leo query transaction {TRANSACTION_ID}
 
 The transaction API endpoint is instructive in verifying whether a transaction succeeded or failed.  Since both successful and failed transaction execute a fee transaction, if only the fee transaction appears, that is a clear indication that the transaction has failed.  Note that on the Testnet and on Mainnet, failed transactions still require a fee since the network is performing a computation.
 
-A full list of API endpoints is available [here](https://developer.aleo.org/apis/provable-api)
+A full list of API endpoints is available [here](https://developer.aleo.org/apis/v2/provable-api)
 
 ## Record Scanning
 

--- a/documentation/language/03_data_types.md
+++ b/documentation/language/03_data_types.md
@@ -154,7 +154,7 @@ program test.aleo {
 
 ### Array
 
-Leo supports static arrays. Array types are declared as `[type; length]` and can be nested. Arrays cannot be empty nor modified.
+Leo supports static arrays. Array types are declared as `[type; length]` and can be nested.
 
 Arrays only support constant accesses. The accessor expression must be a constant expression.
 
@@ -168,6 +168,9 @@ let arr: [bool; 4] = [true, false, true, false];
 
 // Nested array
 let nested: [[bool; 2]; 2] = [[true, false], [true, false]];
+
+// Empty array
+let empty: [u32; 0] = [];
 
 struct Bar {
     data: u8,
@@ -207,7 +210,7 @@ transition sum_with_loop(a: [u64; 4]) -> u64 {
 
 ### Tuple
 
-Leo supports tuples. Tuple types are declared as `(type1, type2, ...)` and can be nested. Tuples cannot be empty or modified.
+Leo supports tuples. Tuple types are declared as `(type1, type2, ...)` and can be nested. Tuples cannot be empty.
 
 Tuples only support constant access with a dot `.` and a constant integer.
 

--- a/documentation/language/08_cheatsheet.md
+++ b/documentation/language/08_cheatsheet.md
@@ -125,8 +125,8 @@ Declaring `arrays`
 ```leo
 let arrb: [bool; 2] = [true, false];
 let arr: [u8; 4] = [1u8, 2u8, 3u8, 4u8]; 
+let empty: [u8; 0] = []; 
 ```
-**Arrays cannot be empty.**
 
 Accessing elements
 ```leo
@@ -154,7 +154,7 @@ Declaring tuples
 ```leo
 let t: (u8, bool, field) = (42u8, true, 100field);
 ```
-**Tuples cannot be empty or modified. Same with arrays.**
+**Tuples cannot be empty.**
 
 Accessing tuple elements
 


### PR DESCRIPTION
Arrays can now be zero sized as per https://github.com/ProvableHQ/leo/pull/28979