### PR TITLE
Add `--json-output` flag documentation for CLI commands

### DIFF
--- a/documentation/cli/00_overview.md
+++ b/documentation/cli/00_overview.md
@@ -63,12 +63,18 @@ Specifies the path to Leo program root folder.  Defaults to `./`.
 #### `--home <HOME>`  
 Specifies the path to the `.aleo` program registry.  This is where programs downloaded from the network will be cached.  Defaults to `~/.aleo/registry`.
 
-#### `--json`
-Outputs results as JSON to stdout. Implies `-q` (suppresses normal CLI output).
+#### `--json-output[=<PATH>]`
+Saves structured JSON output to disk.
 
-Supported commands: `run`, `execute`, `test`, `deploy`, `upgrade`, `query`, `synthesize`.
+- **Default location**: `build/json-outputs/<command>.json`
+- **Custom path**: `--json-output=my-results.json`
 
+Supported commands: `deploy`, `upgrade`, `run`, `execute`, `test`, `query`, `synthesize`.
 
-```bash title="Example: Piping to a File"
-leo run --json main 1u32 2u32 > output.json
+```bash title="Examples"
+# Save to default location (build/json-outputs/run.json)
+leo run --json-output main 1u32 2u32
+
+# Save to custom path
+leo execute main --json-output=my-results.json
 ```

--- a/documentation/cli/06_deploy.md
+++ b/documentation/cli/06_deploy.md
@@ -79,12 +79,17 @@ See the **[Deploying](./../guides/03_deploying.md)** guide for more details.
 
 ### JSON Output
 
-Use the `--json` flag to output results in JSON format for programmatic use:
+Use `--json-output` to save structured JSON results to disk for programmatic use:
 
 ```bash
-leo deploy --json -y
+# Save to default location (build/json-outputs/deploy.json)
+leo deploy --json-output -y
+
+# Save to custom path
+leo deploy --json-output=deployment_result.json -y
 ```
 
+Example output (`build/json-outputs/deploy.json`):
 ```json
 {
   "deployments": [
@@ -99,10 +104,7 @@ leo deploy --json -y
 This is useful for scripting and CI/CD pipelines:
 ```bash
 # Deploy and extract the transaction ID
-leo deploy --json -y | jq '.deployments[0].transaction_id'
-
-# Deploy and save full output to a file
-leo deploy --json -y > deployment_result.json
+jq '.deployments[0].transaction_id' build/json-outputs/deploy.json
 ```
 
 ### Flags:


### PR DESCRIPTION
Documents the `--json-output` flag for saving structured CLI output to disk.

## Changes
- Documents default output location: `build/json-outputs/<command>.json`
- Documents custom path option: `--json-output=path/to/file.json`
- Supported commands: `deploy`, `upgrade`, `run`, `execute`, `test`, `query`, `synthesize`

Related implementation: https://github.com/ProvableHQ/leo/pull/29051